### PR TITLE
Fix duplicate context in DID document

### DIFF
--- a/src/main/java/com/sphereon/factom/identity/did/DIDConstants.java
+++ b/src/main/java/com/sphereon/factom/identity/did/DIDConstants.java
@@ -1,7 +1,6 @@
 package com.sphereon.factom.identity.did;
 
 public class DIDConstants {
-    public static final String JSONLD_DID_DOCUMENT_CONTEXT = "https://www.w3.org/ns/did/v1";
     public static final String JSONLD_TERM_ID = "id";
     public static final String JSONLD_TERM_TYPE = "type";
     public static final String  JSONLD_TERM_CONTROLLER = "controller";

--- a/src/main/java/com/sphereon/factom/identity/did/IdentityFactory.java
+++ b/src/main/java/com/sphereon/factom/identity/did/IdentityFactory.java
@@ -161,7 +161,6 @@ public class IdentityFactory {
 
         // We build using the LdObjects ourselves as the convenience method does not do everything and objects are not mutable anymore
         DIDDocument didDocument = DIDDocument.builder()
-                .context(new URI(DIDConstants.JSONLD_DID_DOCUMENT_CONTEXT))
                 .id(new URI(didurl.getDid().getDidString()))
                 .build();
         didDocument.setJsonObjectKeyValue(DIDKeywords.JSONLD_TERM_AUTHENTICATION, authentications);
@@ -198,7 +197,6 @@ public class IdentityFactory {
             publicKeys.add(publicKey);
         }
         DIDDocument didDocument = DIDDocument.builder()
-                .context(new URI(DIDConstants.JSONLD_DID_DOCUMENT_CONTEXT))
                 .id(new URI(didurl.getDid().getDidString()))
                 .publicKeys(publicKeys)
                 .build();


### PR DESCRIPTION
The update to the DIF library `did-common-java` already sets the context for `DIDDocument` objects by default, and any added contexts are additional. I have removed the context setting so that we do not end up with duplicates.